### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,8 +12,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
+    - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8  # v2
       with:
         node-version: '22'
     - run: npm install


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).